### PR TITLE
schema/relations: import correction (did not work for a db-dump)

### DIFF
--- a/schema/relations.py
+++ b/schema/relations.py
@@ -17,7 +17,7 @@ from yams.buildobjs import SubjectRelation
 from cubicweb.schema import RRQLExpression
 
 # Local import
-from brainomics2.schema.neuroimaging import SCAN_DATA
+from cubes.brainomics2.schema.neuroimaging import SCAN_DATA
 
 
 RELATION_PERMISSIONS = {

--- a/schema/relations.py
+++ b/schema/relations.py
@@ -17,7 +17,7 @@ from yams.buildobjs import SubjectRelation
 from cubicweb.schema import RRQLExpression
 
 # Local import
-from .neuroimaging import SCAN_DATA
+from brainomics2.schema.neuroimaging import SCAN_DATA
 
 
 RELATION_PERMISSIONS = {


### PR DESCRIPTION
The import is working for instance creation and db-create but the procedure of dumoing is failing to import the module.

Works fine in all cases now.
